### PR TITLE
Fix missing dynamics header

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -3,9 +3,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <rosflight_msgs/Command.h>
-#include <rosflight_msgs/Status.h>
-#include <rosflight_msgs/RCRaw.h>
+#include <rosflight_msgs/msg/command.hpp>
+#include <rosflight_msgs/msg/status.hpp>
+#include <rosflight_msgs/msg/rc_raw.hpp>
 
 #include <math.h>
 #include <eigen3/Eigen/Core>
@@ -48,7 +48,7 @@ namespace reef_control
     rclcpp::Subscription<rosflight_msgs::msg::RCRaw>::SharedPtr rc_in_subcriber_;
 
     rclcpp::Time time_of_previous_control_;
-    rosflight_msgs::Command command;
+    rosflight_msgs::msg::Command command;
 
     double mass_;
     double gravity_;

--- a/include/reef_msgs/dynamics.h
+++ b/include/reef_msgs/dynamics.h
@@ -1,0 +1,16 @@
+#ifndef REEF_MSGS_DYNAMICS_H
+#define REEF_MSGS_DYNAMICS_H
+
+#include <geometry_msgs/msg/quaternion.hpp>
+#include <cmath>
+
+namespace reef_msgs {
+inline double get_yaw(const geometry_msgs::msg::Quaternion &q)
+{
+    double siny_cosp = 2.0 * (q.w * q.z + q.x * q.y);
+    double cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z);
+    return std::atan2(siny_cosp, cosy_cosp);
+}
+}
+
+#endif  // REEF_MSGS_DYNAMICS_H

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -108,7 +108,7 @@ namespace reef_control
     }
     */
 
-    command.mode = rosflight_msgs::Command::MODE_ROLL_PITCH_YAWRATE_THROTTLE;
+    command.mode = rosflight_msgs::msg::Command::MODE_ROLL_PITCH_YAWRATE_THROTTLE;
     command.F = std::min(std::max(thrust, 0.0), 1.0);
     //desired_state_.altitude_only = true;
     if(!desired_state_.attitude_valid && !desired_state_.altitude_only) {


### PR DESCRIPTION
## Summary
- add reef_msgs/dynamics.h stub with get_yaw helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847466a84e8832ba2186343066608e5